### PR TITLE
Add peerDependency requirement for @types/sinon-chai

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This plugin adds a Hardhat-ready version of Waffle to the Hardhat Runtime Enviro
 ## Installation
 
 ```bash
-npm install --save-dev @nomiclabs/hardhat-waffle 'ethereum-waffle@^3.0.0' @nomiclabs/hardhat-ethers 'ethers@^5.0.0'
+npm install --save-dev @nomiclabs/hardhat-waffle 'ethereum-waffle@^3.0.0' @nomiclabs/hardhat-ethers 'ethers@^5.0.0' @types/sinon-chai@^3.2.3
 ```
 
 And add the following statement to your `hardhat.config.js`:

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
   },
   "peerDependencies": {
     "@nomiclabs/hardhat-ethers": "^2.0.0",
+    "@types/sinon-chai": "^3.2.3",
     "ethereum-waffle": "*",
     "ethers": "^5.0.0",
     "hardhat": "^2.0.0"


### PR DESCRIPTION
I wrote this comment https://github.com/NomicFoundation/hardhat-waffle/pull/11#issuecomment-1461878816

I think this is necessary to resolve build errors when updating from `2.0.1` to `2.0.5` (traced to `2.0.2` I think). I had to add the `@types/sinon-chai": "^3.2.3"` dependency in my `package.json`

If you choose, you can also upgrade to latest `@types/sinon-chai@^3.2.9` but I didn't include that in the PR

-cory.eth